### PR TITLE
fix: api interceptor에서 토큰을 가져오지 못하는 문제 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cookies-next": "^6.0.0",
         "lucide-react": "^0.513.0",
         "next": "15.3.2",
         "react": "^19.0.0",
@@ -2791,6 +2792,28 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-6.0.0.tgz",
+      "integrity": "sha512-Xq87TPIe7faqluf7gr3mobzO2JRe65oX+pnv4nrnDE/ak49Ic6QhNZSLCk+E5xOKtpVm1EoEazu0iBNyr5TXTA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "next": ">=15.0.0",
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cookies-next": "^6.0.0",
     "lucide-react": "^0.513.0",
     "next": "15.3.2",
     "react": "^19.0.0",

--- a/src/app/users/login/naver/success/page.tsx
+++ b/src/app/users/login/naver/success/page.tsx
@@ -3,11 +3,12 @@
 import { useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/auth/useAuthStore";
+import { setCookie } from "cookies-next";
 
 export default function NaverLoginCallbackPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const login = useAuthStore((state: { login: any; }) => state.login);
+  const login = useAuthStore((state: { login: any }) => state.login);
 
   useEffect(() => {
     const accessToken = searchParams.get("accessToken");
@@ -19,8 +20,12 @@ export default function NaverLoginCallbackPage() {
     }
 
     login(accessToken, isNewUser);
-    
-    router.replace("/"); 
+    setCookie("accessToken", accessToken, {
+      maxAge: 60 * 60 * 24,
+      secure: false,
+    });
+
+    router.replace("/");
   }, [searchParams, router, login]);
 
   return <div></div>;

--- a/src/features/detail/components/NewsSourceCardList.tsx
+++ b/src/features/detail/components/NewsSourceCardList.tsx
@@ -16,15 +16,17 @@ function NewsSourceCard({
   );
 }
 
-
-export default function NewsSourceCardList({ newsSourceList }: { newsSourceList: NewsSource[]; }) {
-
+export default function NewsSourceCardList({
+  newsSourceList,
+}: {
+  newsSourceList: NewsSource[];
+}) {
   return (
     <div className="mt-55">
       <div className="font-title-24">이런 기사들을 모았어요</div>
       <div className="mt-15 flex gap-20">
         {newsSourceList.map((item, index) => (
-          <a href={item.url} target="_blank">
+          <a key={index} href={item.url} target="_blank">
             <NewsSourceCard
               key={index}
               company={item.pressCompany}

--- a/src/features/detail/components/api/newsDetail.ts
+++ b/src/features/detail/components/api/newsDetail.ts
@@ -1,5 +1,5 @@
 import ApiException from "@/exception/apiException";
-import api from "@/utils/axios";
+import apiClient from "@/utils/apiClient";
 
 export default async function fetchNewsDetail({
   id,
@@ -11,7 +11,7 @@ export default async function fetchNewsDetail({
   const params = { "article-id": id };
   const headers = containsAuthHeader ? {} : { "x-auth-not-required": "true" }; // 오늘의 뉴스일 경우 헤더 불필요
   try {
-    const response = await api.get("/article", {
+    const response = await apiClient.get("/article", {
       params,
       headers,
     });

--- a/src/features/recommended-news/api/news.ts
+++ b/src/features/recommended-news/api/news.ts
@@ -1,5 +1,5 @@
 import ApiException from "@/exception/apiException";
-import api from "@/utils/axios";
+import apiServer from "@/utils/apiServer";
 
 export default async function fetchRecommendedNewsCardList({
   selectedCategory,
@@ -8,7 +8,7 @@ export default async function fetchRecommendedNewsCardList({
 }) {
   const params = { category: encodeURIComponent(selectedCategory) };
   try {
-    const response = await api.get("/articles/recommend", {
+    const response = await apiServer.get("/articles/recommend", {
       params
     });
     return response.data;

--- a/src/features/recommended-news/components/RecommendedNews.tsx
+++ b/src/features/recommended-news/components/RecommendedNews.tsx
@@ -2,6 +2,7 @@ import { NewsSummary } from "@/types/news/newsSummary";
 import fetchRecommendedNewsCardList from "../api/news";
 import { dummyNews } from "@/mock/dummyNews";
 import RecommendedNewsCardList from "./RecommendedNewsCardList";
+import NoContent from "@/features/common/NoContent";
 
 export default async function RecommendedNews() {
     const newsList = (await fetchRecommendedNewsCardList({
@@ -21,19 +22,23 @@ export default async function RecommendedNews() {
   }
 
   // 카테고리 정렬 (가나다순)
-  const sortdCategories = Object.keys(newsByCategory).sort((a, b) =>
+  const sortedCategories = Object.keys(newsByCategory).sort((a, b) =>
     a.localeCompare(b, "ko"),
   );
     
   return (
     <div>
-      {sortdCategories.map((category, index) => (
-        <RecommendedNewsCardList
-          key={index}
-          category={category}
-          newsList={newsByCategory[category]}
-        />
-      ))}
+      {newsList.length === 0 ? (
+        <NoContent message={"불러올 뉴스가 없어요."} />
+      ) : (
+        sortedCategories.map((category) => (
+          <RecommendedNewsCardList
+            key={category}
+            category={category}
+            newsList={newsByCategory[category] ?? []}
+          />
+        ))
+      )}
     </div>
   );
 }

--- a/src/features/recommended-news/components/RecommendedNewsCardGrid.tsx
+++ b/src/features/recommended-news/components/RecommendedNewsCardGrid.tsx
@@ -13,7 +13,7 @@ export default async function RecommendedNewsCardGrid({
   className?: string;
 }) {
   const newsList = await fetchRecommendedNewsCardList({
-    selectedCategory: categoryLabel ?? "전체",
+    selectedCategory: categoryLabel ?? "",
   });
   return (
     <div className="mt-45">

--- a/src/features/signup/api/signup.ts
+++ b/src/features/signup/api/signup.ts
@@ -1,9 +1,9 @@
 import ApiException from "@/exception/apiException";
-import api from "@/utils/axios";
+import apiClient from "@/utils/apiClient";
 
 export default async function registerUser(name: string, categories: string[]) {
   try {
-    const response = await api.post(
+    const response = await apiClient.post(
       `/users/registration?nickname=${encodeURIComponent(name)}`,
       categories,
     );

--- a/src/features/today-news/api/news.ts
+++ b/src/features/today-news/api/news.ts
@@ -1,5 +1,5 @@
 import ApiException from "@/exception/apiException";
-import api from "@/utils/axios";
+import apiServer from "@/utils/apiServer";
 
 export default async function fetchNewsCardList({
   selectedCategory
@@ -8,7 +8,7 @@ export default async function fetchNewsCardList({
 }) {
   const params = { category: encodeURIComponent(selectedCategory) };
   try {
-    const response = await api.get("/articles", {
+    const response = await apiServer.get("/articles", {
       params,
       headers: {
         "x-auth-not-required": "true", // 인증 헤더 제외

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -1,0 +1,78 @@
+import ApiException from "@/exception/apiException";
+import axios from "axios";
+import { getCookie } from "cookies-next";
+
+// '클라이언트 컴포넌트용' 요청/응답 인터셉트 및 로깅
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_SERVER_URL,
+  timeout: 10000,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+axios.defaults.withCredentials = true;
+
+// 요청 인터셉터
+apiClient.interceptors.request.use(
+  (config) => {
+    const accessToken = getCookie("accessToken");
+    const skipAuth = config.headers?.["x-auth-not-required"]; // 인증 헤더가 필요 없는 경우 포함
+
+    console.log(`🚀 [Request] ${config.method?.toUpperCase()} ${config.url}`, { // 요청 로그
+      config,
+    });
+
+    if (skipAuth) {
+      return config;
+    }
+
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    } else {
+      console.warn("🔐 [Auth Warning] accessToken이 없습니다.");
+    }
+    return config;
+  },
+  (error) => {
+    console.error("❌ [Request Error]", error);
+    return Promise.reject(error);
+  },
+);
+
+apiClient.interceptors.response.use(
+  (response) => {
+    console.log(response);
+    const { status, config, data } = response;
+    console.log(status, config, data);
+    if (status >= 200 && status < 300) {
+      // 성공 응답
+      console.log(`💡 [Response] ${status} ${config.url}`, data);
+      return response;
+    } else {
+      return Promise.reject(response);
+    }
+  },
+  (error) => {
+    if (error.response) {
+      const { status, config, data } = error.response;
+      const url = config?.url || "";
+
+      if (status >= 400 && status < 500) {
+        console.error(`[❌ Error] ${status} ${config.url}`, data);
+        const customMessage = data?.message || "";
+        return Promise.reject(
+          new ApiException(customMessage, status, data, url),
+        );
+      } else if (status >= 500) {
+        // 서버 에러
+        console.error(`[❌ Server Error] ${status} ${config.url}`, data);
+      }
+    }
+    return Promise.reject(error); // 이후 catch문에서 처리
+  },
+);
+
+export default apiClient;

--- a/src/utils/apiServer.ts
+++ b/src/utils/apiServer.ts
@@ -1,11 +1,10 @@
 import ApiException from "@/exception/apiException";
-import { useAuthStore } from "@/stores/auth/useAuthStore";
 import axios from "axios";
 
-// 요청/응답 인터셉트 및 로깅
+// '서버 컴포넌트용' 요청/응답 인터셉트 및 로깅
 
 // Axios 인스턴스 생성
-const api = axios.create({
+const apiServer = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_SERVER_URL,
   timeout: 10000,
   headers: {
@@ -15,16 +14,17 @@ const api = axios.create({
 
 axios.defaults.withCredentials = true;
 
-
 // 요청 인터셉터
-api.interceptors.request.use(
-  (config) => {
-    const { accessToken } = useAuthStore.getState();
+apiServer.interceptors.request.use(
+  async (config) => {
+    const { cookies } = await import("next/headers");
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get("accessToken")?.value;
 
     const skipAuth = config.headers?.["x-auth-not-required"]; // 인증 헤더가 필요 없는 경우 포함
 
     console.log(`🚀 [Request] ${config.method?.toUpperCase()} ${config.url}`, { // 요청 로그
-      config
+      config,
     });
 
     if (skipAuth) {
@@ -44,12 +44,11 @@ api.interceptors.request.use(
   },
 );
 
-
-api.interceptors.response.use(
+apiServer.interceptors.response.use(
   (response) => {
     console.log(response);
     const { status, config, data } = response;
-    console.log(status, config, data)
+    console.log(status, config, data);
     if (status >= 200 && status < 300) {
       // 성공 응답
       console.log(`💡 [Response] ${status} ${config.url}`, data);
@@ -73,9 +72,9 @@ api.interceptors.response.use(
         // 서버 에러
         console.error(`[❌ Server Error] ${status} ${config.url}`, data);
       }
-    } 
+    }
     return Promise.reject(error); // 이후 catch문에서 처리
   },
 );
 
-export default api;
+export default apiServer;


### PR DESCRIPTION
<!-- 제목 예시 ) Feat: 작업 내용 영어로 (#이슈번호) -->

## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 관련된 이슈 넘버


## ✅ 작업 목록
- 기존 문제: localStorage에 저장된 토큰이 axios.ts 파일의 api 객체의 요청 interceptor 내부에서 토큰 값을 가져오지 못하는 문제 발생
- 원인: 서버 컴포넌트는 브라우저에 접근할 수 없으므로 서버 컴포넌트에서 api 요청을 보낼 경우 localStorage  토큰 값을 가져오지 못함
- 해결: 토큰을 쿠키🍪에 저장하고, axios.ts 파일을 ❗️클라이언트 컴포넌트 호출용(apiClient.ts) / 서버 컴포넌트 호출용(apiServer.ts)으로 분리❗️하여 작성

- 사용방법
1️⃣ 서버 컴포넌트에서 api 함수를 호출할 경우 -> import apiServer from "@/utils/apiServer"; 
2️⃣ 클라이언트 컴포넌트에서 api 함수를 호출할 경우 -> import apiClient from "@/utils/apiClient";


## 📚 논의사항
- 기존 토큰 저장 로직(zustand)은 유지
- 로그아웃 시 '쿠키'에 있는 토큰 제거와 zustand 로그아웃 함께 처리

## 📚 ETC
- 패키지 추가: cookies-next: 6.0.0
- https://www.npmjs.com/package/cookies-next
