### PR TITLE
css: 반응형 브레이크 포인트 설정 변경

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,11 +18,9 @@ const config: Config = {
   theme: {
     extend: {
       screens: {
-        mobile: '390px',
-        // sm: '640px',
-        tablet: '768px',
-        pc: '1024px',
-        // xl: '1280px',
+        sm: { 'max': '849px' },
+        md: { 'min': '850px', 'max': '1279px' },
+        xl: '1280px',
       },
       borderWidth: px0_10,
       borderRadius: px0_100,


### PR DESCRIPTION
<!-- 제목 예시 ) Feat: 작업 내용 영어로 (#이슈번호) -->

## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [] 🌍 빌드 설정 및 문제
- [ ] ETC

## ✅ 작업 목록
- 브레이크 포인트 설정 변경

## 📚 논의사항
- 브레이크 포인트 값을 `850`, `1280`으로 변경
- 브레이크 포인트 네이밍 `sm`, `md`, `xl`로 변경
  - 변경 이유: 기존 mobile, tablet, pc에 따라 정확하게 디자인이 분기되는 것이 아니므로 보다 직관적인 네이밍 사용

## 🔧 브레이크 포인트 사용 규칙
- `sm:`: width <= 849px 에서 사용 (모바일용 디자인 적용)
- `md:`: 850px <= width <= 1279px 에서 사용 (기존 웹 사이즈 디자인 유지하되, 일부분만 수정)
- `xl`: width >= 1280px에서 사용 (현재 디자인 적용)
