### PR TITLE
hotfix: 추천 뉴스 조회 로직 변경

### DIFF
--- a/src/features/recommended-news/components/RecommendedNews.tsx
+++ b/src/features/recommended-news/components/RecommendedNews.tsx
@@ -9,59 +9,70 @@ import LoadingSpinner from "@/components/LoadingSpinner";
 import { isLoggedInUser, useAuthStore } from "@/stores/auth/useAuthStore";
 import { useDeviceStore } from "@/stores/device/useDeviceStore";
 import RecommendedNewsCarouselList from "./RecommendedNewsCarouselList";
+import { useUserStore } from "@/stores/auth/useUserStore";
 
 export default function RecommendedNews() {
   const isMobile = useDeviceStore((state) => state.isMobile);
-
   const isUser = useAuthStore(isLoggedInUser);
-  const [newsList, setNewsList] = useState<NewsSummary[] | null>(null);
-  const [itemsPerPage, setItemsPerPage] = useState(0);
+  const userCategories = useUserStore((state) => state.categories);
+
+  const [newsByCategory, setNewsByCategory] = useState<
+    Record<string, NewsSummary[]>
+  >({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!isUser) return;
+    if (!isUser || !userCategories || userCategories.length === 0) {
+      setLoading(false);
+      return;
+    }
+
     const fetchData = async () => {
-      try {
-        const newsCardListResponse = await fetchRecommendedNewsCardList({
-          selectedCategory: "전체",
+      // 카테고리마다 뉴스 조회 요청 병렬 처리
+      const promises = userCategories.map((category) =>
+        fetchRecommendedNewsCardList({
+          selectedCategory: category,
           selectedPressCompanyName: "전체",
-          page: 1
-        });
-        setNewsList(Array.isArray(newsCardListResponse.articleInfos) ? newsCardListResponse.articleInfos : []);
-        setItemsPerPage(newsCardListResponse.limit);
-      } catch (error) {
-        console.error("추천 뉴스 불러오기 실패", error);
-        setNewsList([]);
-      } finally {
-        setLoading(false);
-      }
+          page: 1,
+        })
+          .then((res) => {
+            const articles = Array.isArray(res.articleInfos)
+              ? res.articleInfos
+              : [];
+            // 응답이 오는 즉시 상태 업데이트 (부분 렌더링)
+            setNewsByCategory((prev) => ({
+              ...prev,
+              [category]: articles,
+            }));
+          })
+          .catch((error) => {
+            console.error(`카테고리 [${category}] 뉴스 불러오기 실패`, error);
+            setNewsByCategory((prev) => ({
+              ...prev,
+              [category]: [],
+            }));
+          }),
+      );
+
+      // 모든 요청이 끝나면 로딩 false
+      await Promise.allSettled(promises);
+      setLoading(false);
     };
 
     fetchData();
-  }, []);
+  }, [isUser, userCategories]);
 
-  if (!isUser) {
-    return <NoContent message="로그인 후 이용할 수 있어요." />;
-  }
-  if (loading) {
-    return <LoadingSpinner />;
-  }
-  if (!newsList || newsList.length === 0) {
+  if (!isUser) return <NoContent message="로그인 후 이용할 수 있어요." />;
+
+  const categoryKeys = Object.keys(newsByCategory);
+  const hasAnyNews = categoryKeys.some(
+    (key) => newsByCategory[key]?.length > 0,
+  );
+
+  if (!loading && !hasAnyNews)
     return <NoContent message="불러올 추천 뉴스가 없어요." />;
-  }
 
-  const newsByCategory: Record<string, NewsSummary[]> = {};
-
-  for (const news of newsList) {
-    const category = news.categories[0] || "기타";
-    if (!newsByCategory[category]) {
-      newsByCategory[category] = [news];
-    } else if (newsByCategory[category].length < itemsPerPage) {
-      newsByCategory[category].push(news);
-    }
-  }
-
-  const sortedCategories = Object.keys(newsByCategory).sort((a, b) =>
+  const sortedCategories = categoryKeys.sort((a, b) =>
     a.localeCompare(b, "ko"),
   );
 
@@ -82,6 +93,7 @@ export default function RecommendedNews() {
           />
         ),
       )}
+      {loading && <LoadingSpinner />}
     </div>
   );
 }


### PR DESCRIPTION
<!-- 제목 예시 ) Feat: 작업 내용 영어로 (#이슈번호) -->

## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC




## ✅ 작업 목록
- 페이징 도입에 따라 카테고리 목록 추천 뉴스 조회 시 특정 카테고리 뉴스가 표시되지 않는 문제 해결
- useUserStore에 저장된 관심 카테고리 정보를 먼저 가져와서, 카테고리마다 뉴스 api를 호출하는 방향으로 리팩터링
- Promise.allSettled를 사용해 부분 렌더링 가능하도록 수정